### PR TITLE
Use webpack instead of react-scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@
 /coverage
 
 # production
-/build
+public/build
+
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "main": "server/index.js",
   "dependencies": {
+    "babel-preset-es2015": "^6.24.0",
+    "css-loader": "^0.28.0",
     "express": "^4.15.2",
     "faker": "^4.1.0",
     "material-ui": "^0.17.1",
@@ -13,7 +15,9 @@
     "react-edit-inline": "^1.0.8",
     "react-flexbox-grid": "^1.0.2",
     "react-router-dom": "^4.0.0",
-    "react-tap-event-plugin": "^2.0.1"
+    "react-tap-event-plugin": "^2.0.1",
+    "style-loader": "^0.16.1",
+    "webpack": "^2.3.3"
   },
   "devDependencies": {
     "react-scripts": "0.9.5"
@@ -22,6 +26,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "watch": "rm -rf public/dist/ && webpack --progress --watch"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,10 +23,8 @@
     "react-scripts": "0.9.5"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject",
-    "watch": "rm -rf public/dist/ && webpack --progress --watch"
+    "start": "node server/",
+    "watch": "rm -rf public/dist/ && webpack --progress --watch",
+    "build": "rm -rf public/dist/ && webpack --progress"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -4,28 +4,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="favicon.ico">
-    <!--
-      Notice the use of %PUBLIC_URL% in the tag above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
     <title>Treedoff</title>
   </head>
   <body>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start`.
-      To create a production bundle, use `npm run build`.
-    -->
+    <script src="build/bundle.js"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="build/bundle.js"></script>
+    <script src="/build/bundle.js"></script>
   </body>
 </html>

--- a/server/index.js
+++ b/server/index.js
@@ -14,7 +14,7 @@ app.use(bodyParser.urlencoded({ extended: true }))
 app.use(bodyParser.json())
 
 // Serve static assets
-app.use(express.static(path.resolve(__dirname, '..', 'build')))
+app.use(express.static(path.resolve(__dirname, '..', 'public')))
 
 // api definitions
 const api = require('./api');
@@ -26,7 +26,7 @@ app.get('/d3', (req, res) => {
 
 // Always return the main index.html, so react-router render the route in the client
 app.get('*', (req, res) => {
-    res.sendFile(path.resolve(__dirname, '..', 'build', 'index.html'));
+    res.sendFile(path.resolve(__dirname, '..', 'public', 'index.html'));
 });
 
 module.exports = app;

--- a/server/index.js
+++ b/server/index.js
@@ -18,7 +18,7 @@ app.use(express.static(path.resolve(__dirname, '..', 'public')))
 
 // check for react files
 const fs = require('fs')
-fs.access(path.resolve(__dirname, '..', 'public', 'build'), (err) => {
+fs.access(path.resolve(__dirname, '..', 'public', 'build'), fs.constants.F_OK | fs.constants.R_OK, (err) => {
   if(err) {
     const suggestion = " --> The React.js application was probably not built"
     throw err + suggestion

--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,15 @@ app.use(bodyParser.json())
 // Serve static assets
 app.use(express.static(path.resolve(__dirname, '..', 'public')))
 
+// check for react files
+const fs = require('fs')
+fs.access(path.resolve(__dirname, '..', 'public', 'build'), (err) => {
+  if(err) {
+    const suggestion = " --> The React.js application was probably not built"
+    throw err + suggestion
+  }
+});
+
 // api definitions
 const api = require('./api');
 app.get('/api', api.getTree);

--- a/src/components/add-arg.js
+++ b/src/components/add-arg.js
@@ -29,7 +29,7 @@ class AddArg extends Component {
   render() {
     return (
       <Grid>
-        <Row style={{"margin-top": "35px"}}>
+        <Row style={{marginTop: "35px"}}>
           <Col sm={4}/>
           <Col sm={4} xs={12}>
             <img src={Label} className="App-logo center" alt="logo" />

--- a/src/components/history.js
+++ b/src/components/history.js
@@ -6,6 +6,13 @@ import UndoIcon from 'material-ui/svg-icons/content/undo.js'
 
 export default class History extends Component {
 
+  constructor(props) {
+    super(props)
+
+    this.regress = this.regress.bind(this)
+    this.generateHistory = this.generateHistory.bind(this)
+  }
+
   regress(amt) {
     this.props.regress(amt)
   }

--- a/src/components/history.js
+++ b/src/components/history.js
@@ -6,11 +6,11 @@ import UndoIcon from 'material-ui/svg-icons/content/undo.js'
 
 export default class History extends Component {
 
-  regress = (amt) => {
+  regress(amt) {
     this.props.regress(amt)
   }
 
-  generateHistory = () => {
+  generateHistory() {
     var events = []
     var currentStatement = this.props.data.tree
     for(var i = 0; i < this.props.data.path.length; i++) {

--- a/src/components/statement.js
+++ b/src/components/statement.js
@@ -31,11 +31,11 @@ export default class Statement extends Component {
     }
   }
 
-  setConfidence = (event, value) => {
+  setConfidence(event, value) {
     this.props.setConfidence(value)
   }
 
-  addStatement = (pro) => {
+  addStatement(pro) {
     if(this.refs[(pro ? "addPro" : "addCon")].input.value.length !== 0) {
       this.props.addStatement(
         pro,
@@ -46,7 +46,7 @@ export default class Statement extends Component {
     return false
   }
 
-  renderPros = () => {
+  renderPros() {
     var rows = []
     var byConfidence = (b, a) => (a.confidence - b.confidence)
     const pros = this.props.pros.sort(byConfidence)
@@ -69,9 +69,9 @@ export default class Statement extends Component {
     return rows
   }
 
-  renderCons = () => {
+  renderCons() {
     var rows = []
-    var byConfidence = (b, a) => (a.confidence - b.confidence)
+    const byConfidence = (b, a) => (a.confidence - b.confidence)
     const cons = this.props.cons.sort(byConfidence)
     const num_arguments = cons.length
     for(var i = 0; i < num_arguments; i++) {
@@ -92,7 +92,7 @@ export default class Statement extends Component {
     return rows
   }
 
-  renderProgress = () => {
+  renderProgress() {
     return this.state.editing ? (
       <Slider value={ 0.5 } onChange={this.setConfidence}/>
     ) : (

--- a/src/components/statement.js
+++ b/src/components/statement.js
@@ -29,6 +29,12 @@ export default class Statement extends Component {
       confidence: this.props.confidence,
       editing: false
     }
+
+    this.setConfidence = this.setConfidence.bind(this)
+    this.addStatement = this.addStatement.bind(this)
+    this.renderPros = this.renderPros.bind(this)
+    this.renderCons = this.renderCons.bind(this)
+    this.renderProgress = this.renderProgress.bind(this)
   }
 
   setConfidence(event, value) {

--- a/src/components/tree.js
+++ b/src/components/tree.js
@@ -42,17 +42,26 @@ export default class Tree extends Component {
       // loading icon indication
       loading: false
     }
+
+    this.saveTree = this.saveTree.bind(this)
+    this.advancePath = this.advancePath.bind(this)
+    this.regressPath = this.regressPath.bind(this)
+    this.setConfidence = this.setConfidence.bind(this)
+    this.setDescription = this.setDescription.bind(this)
+    this.setSource = this.setSource.bind(this)
+    this.setTitle = this.setTitle.bind(this)
+    this.addStatement = this.addStatement.bind(this)
+    this.removeStatement = this.removeStatement.bind(this)
   }
 
   componentDidMount() {
     fetch("/api")
       .then(res => res.json())
       .then(data => this.setState({tree: data}))
-      .catch(() => console.log("Could not fetch data =("));
+      .catch(() => console.log("Could not fetch data =("))
   }
 
-  // https://www.youtube.com/watch?v=1LI81cWh3Fs
-  saveTree = () => {
+  saveTree() {
     fetch('/api/tree', {
       credentials: 'same-origin',
       body: JSON.stringify(this.state.tree),
@@ -63,19 +72,19 @@ export default class Tree extends Component {
     }).then(res => console.log(res.status))
   }
 
-  advancePath = (pro, index) => {
+  advancePath(pro, index) {
     this.setState({
       path: this.state.path.concat((pro ? "pros" : "cons") + index)
     })
   }
 
-  regressPath = (amt) => {
+  regressPath(amt) {
     this.setState({
       path: this.state.path.slice(0, amt)
     })
   }
 
-  setConfidence = (confidence) => {
+  setConfidence(confidence) {
     let copiedTree = Object.assign({}, this.state.tree)
 
     var currentStatement = copiedTree
@@ -89,7 +98,7 @@ export default class Tree extends Component {
     this.setState({tree: copiedTree})
   }
 
-  setDescription = (data) => {
+  setDescription(data) {
     let copiedTree = Object.assign({}, this.state.tree)
 
     var currentStatement = copiedTree
@@ -103,7 +112,7 @@ export default class Tree extends Component {
     this.setState({tree: copiedTree})
   }
 
-  setSource = (data) => {
+  setSource(data) {
     let copiedTree = Object.assign({}, this.state.tree)
 
     var currentStatement = copiedTree
@@ -117,7 +126,7 @@ export default class Tree extends Component {
     this.setState({tree: copiedTree})
   }
 
-  setTitle = (data) => {
+  setTitle(data) {
     let copiedTree = Object.assign({}, this.state.tree)
 
     var currentStatement = copiedTree
@@ -132,7 +141,7 @@ export default class Tree extends Component {
     this.setState({tree: copiedTree})
   }
 
-  addStatement = (pro, statement) => {
+  addStatement(pro, statement) {
     let copiedTree = Object.assign({}, this.state.tree)
 
     var currentStatement = copiedTree
@@ -147,7 +156,7 @@ export default class Tree extends Component {
     this.setState({tree: copiedTree})
   }
 
-  removeStatement = (pro, index) => {
+  removeStatement(pro, index) {
     let copiedTree = Object.assign({}, this.state.tree)
 
     var currentStatement = copiedTree

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,46 @@
+const path = require('path')
+const env = process.env.NODE_ENV || 'development'
+const webpack = require('webpack')
+const LANG = process.env.LANG || 'en-US'
+const dist = path.join(__dirname, 'public')
+
+module.exports = [
+  {
+    name: 'JS',
+    devtool: 'source-map',
+    entry: ['whatwg-fetch', path.join(__dirname, 'src', 'index.js')],
+    output: {
+      filename: path.join('public', 'build', 'bundle.js')
+    },
+    plugins: [
+      new webpack.ProvidePlugin({
+          "react": "React",
+      })
+    ],
+
+    module: {
+      loaders: [{
+          test: /\.jsx?$/,
+          loader: 'babel-loader',
+          exclude: [
+            /node_modules\//
+          ],
+          query: {
+            presets: [
+              require.resolve('babel-preset-es2015'),
+              require.resolve('babel-preset-react')
+            ]
+          }
+        },
+        {
+          test: /\.css$/,
+          use: [ 'style-loader', 'css-loader' ]
+        },
+        {
+          test: /\.svg$/,
+          loader: 'babel-loader?presets[]=es2015,presets[]=react!svg-react-loader'
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
This allows to more quickly work on the front end when developing by not needed to re-compile from scratch. These changes mostly manifests themselves in the following scripts:

- `npm run watch` - runs webpack in `--watch` mode, listening for changes and only recompiling the relevant parts when anything in the `src` directory is edited.
- `npm run build`- build whole thing from scratch
- `npm start` - start the server will check if there a React build exists, and aborts otherwise.